### PR TITLE
Removed duplication in npm scripts `serve` and `watch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "npm run build && npm run watch",
     "build": "npm run build-sass && npm run build-ts && npm run tslint && npm run copy-static-assets",
-    "serve": "node dist/server.js",
-    "watch": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"nodemon dist/server.js\"",
+    "serve": "nodemon dist/server.js",
+    "watch": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run serve\"",
     "test": "jest --forceExit",
     "build-ts": "tsc",
     "watch-ts": "tsc -w",


### PR DESCRIPTION
npm script `serve` was orphant. Replaced it with `nodemon dist/server.js` from the end of `watch` script and placed it's execution in the end of `watch` script to remove duplication at all.