### PR TITLE
fix: fix lint warnings for test files

### DIFF
--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,5 @@
+import {} from 'jest';
 import * as supertest from "supertest";
-import {default as app} from "../src/server";
 
 const request = supertest("http://localhost:8000");
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,3 +1,4 @@
+import {} from 'jest';
 import * as supertest from "supertest";
 const request = supertest("http://localhost:8000");
 

--- a/test/contact.test.ts
+++ b/test/contact.test.ts
@@ -1,3 +1,4 @@
+import {} from 'jest';
 import * as supertest from "supertest";
 const request = supertest("http://localhost:8000");
 

--- a/test/home.test.ts
+++ b/test/home.test.ts
@@ -1,3 +1,4 @@
+import {} from 'jest';
 import * as supertest from "supertest";
 const request = supertest("http://localhost:8000");
 

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -1,3 +1,4 @@
+import {} from 'jest';
 import * as supertest from "supertest";
 const request = supertest("http://localhost:8000");
 


### PR DESCRIPTION
Though tests can be run since the testing files won't need to go through tslint, but warnings will  appear on all the testing files regarding `describe` and `it`. I have applied a simple fix by simply `import {} from 'jest';`

app.test.ts
![screen shot 2017-07-23 at 4 47 13 pm](https://user-images.githubusercontent.com/13964463/28498031-a35fde6c-6fc7-11e7-9bc2-8bdf96692a98.png)

![screen shot 2017-07-23 at 4 44 25 pm](https://user-images.githubusercontent.com/13964463/28498028-8d3a5b80-6fc7-11e7-81aa-c6f8a37aeea1.png)

![screen shot 2017-07-23 at 4 44 43 pm](https://user-images.githubusercontent.com/13964463/28498030-9efd23ca-6fc7-11e7-9025-d0cfba710422.png)
