### PR TITLE
Bump tasks.json version from 0.10 to 2.00. Add default build task.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,16 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-    "version": "0.1.0",
-    "command": "npm",
-    "isShellCommand": true,
-    "showOutput": "always",
-    "suppressTaskName": true,
+    "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "build",
-            "args": ["run", "build"]
+            "taskName": "Run Build",
+            "type": "npm",
+            "script": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         }
     ]
 }


### PR DESCRIPTION
I noticed the .vscode/tasks.json file was still using the version 0.1.0 format, so I replaced it with a file that executes the same task using the new 2.0.0 version:
https://code.visualstudio.com/docs/editor/tasks#_convert-from-010-to-200