### PR TITLE
Update debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
             "outFiles": [
                 "../dist/**/*.js"
             ],
-            "preLaunchTask": "build",
+            "preLaunchTask": "npm: build",
             "protocol": "inspector"
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "Run Build",
             "type": "npm",
             "script": "build",
             "group": {


### PR DESCRIPTION
This PR simply updates the debug configuration's `preLaunchTask` setting, in order to accomodate the new auto-detection of NPM scripts. Without this change, I receive the following error when trying to debug this starter using VS Code 1.15:

<img width="1061" alt="screen shot 2017-07-30 at 10 09 42 pm" src="https://user-images.githubusercontent.com/116461/28763599-1ed294de-7574-11e7-9c7e-4b2191147661.png">

Alternatively, we could update the `tasks.json` file to set the build task's `taskName` property to `build`. However, the `taskName` property is now deprecated (in favor of `label`), and the build task doesn't really need a `label` anyways since it's only being defined via `tasks.json` in order to configure it as the default build task.