### PR TITLE
Docker (+ mongoose updates)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+dist/
+node_modules/
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:latest
+
+ADD ./package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN mkdir -p /starter && cp -a /tmp/node_modules /starter
+
+WORKDIR /starter
+ADD . /starter
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  starter:
+    build: .
+    ports:
+      - "3000:3000"
+    links:
+      - mongo
+    environment:
+      - MONGODB_URI=mongodb://mongo/typescript-node-starter
+  mongo:
+    image: mongo
+    volumes:
+      - /tmp/mongo/db:/data/db
+    ports:
+      - "27017:27017"
+    command: "--smallfiles -logpath=/dev/null"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "copy-static-assets": "node copyStaticAssets.js",
     "debug": "npm run build && npm run watch-debug",
     "serve-debug": "nodemon --inspect dist/server.js",
-    "watch-debug": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run serve-debug\""
+    "watch-debug": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run serve-debug\"",
+    "docker": "docker-compose up --build"
   },
   "jest": {
     "globals": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "bcrypt-nodejs": "^0.0.3",
     "body-parser": "^1.15.2",
     "compression": "^1.6.2",
-    "connect-mongo": "^1.3.2",
+    "connect-mongo": "^2.0.0",
     "dotenv": "^2.0.0",
     "errorhandler": "^1.4.3",
     "express": "^4.14.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,8 +46,10 @@ const app = express();
 /**
  * Connect to MongoDB.
  */
-// mongoose.Promise = global.Promise;
-mongoose.connect(process.env.MONGODB_URI || process.env.MONGOLAB_URI);
+(<any>mongoose).Promise = /* mongoose.Promise = */global.Promise;
+mongoose.connect(process.env.MONGODB_URI || process.env.MONGOLAB_URI, {
+  useMongoClient: true
+});
 
 mongoose.connection.on("error", () => {
   console.log("MongoDB connection error. Please make sure MongoDB is running.");


### PR DESCRIPTION
1. Adds container support/example (dockerfile & docker-compose). Start using `npm run docker`
2. Minor fixes to remove deprecated issues around mongoose/connect-mongo)