### PR TITLE
Add VSCode CosmosDB extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "eg2.tslint",
+        "ms-azuretools.vscode-cosmosdb",
         "streetsidesoftware.code-spell-checker"
     ]
 }


### PR DESCRIPTION
The VSCode CosmosDB supports locally installed MongoDB servers
(and lot of other things and features).
It seems reasonable to offer that extension to project users.

Thanks!