### PR TITLE
added 'npm run build' to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ mongod
 ```
 - Build and run the project
 ```
+npm run build
 npm start
 ```
 Navigate to `http://localhost:3000`


### PR DESCRIPTION
The README.md was missing a step (npm run build). Without it, when one tried 'npm start', an error follows. The 'npm run build' is a required step which was erroneously omitted from the README.md file.