### PR TITLE
changed description of npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Below is a list of all the scripts this template has available:
 
 | Npm Script | Description |
 | ------------------------- | ------------------------------------------------------------------------------------------------- |
-| `start`                   | Runs full build before starting all watch tasks. Can be invoked with `npm start`                  |
+| `start`                   | Does the same as 'npm run serve'. Can be invoked with `npm start`                                      |
 | `build`                   | Full build. Runs ALL build tasks (`build-sass`, `build-ts`, `tslint`, `copy-static-assets`)       |
 | `serve`                   | Runs node on `dist/server.js` which is the apps entry point                                       |
 | `watch`                   | Runs all watch tasks (TypeScript, Sass, Node). Use this if you're not touching static assets.     |


### PR DESCRIPTION
The description for npm start is not correct. It does not do a full build. Changed the description in the table to reflect what the actual behavior is.