### PR TITLE
Update view markups for HTML5 compatibility

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,12 +1,13 @@
 doctype html
-html
+html(lang='')
   head
     meta(charset='utf-8')
     meta(http-equiv='X-UA-Compatible', content='IE=edge')
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
+    title #{title} - Hackathon Starter
+    meta(name='description', content='')
     meta(name='theme-color' content='#4DA5F4')
     meta(name='csrf-token', content=_csrf)
-    title #{title} - Hackathon Starter
     link(rel='shortcut icon', href='/images/favicon.png')
     link(rel='stylesheet', href='/css/main.css')
 
@@ -23,11 +24,8 @@ html
     script(src='/js/lib/bootstrap.min.js')
     script(src='/js/main.js')
 
-    // Google Analytics: change UA-XXXXX-X to be your site's ID
+    //- Google Analytics: change UA-XXXXX-X to be your site's ID
     script.
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-XXXXX-X', 'auto');
-      ga('send', 'pageview');
+      window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;
+      ga('create','UA-XXXXX-Y','auto');ga('send','pageview')
+    script(src='https://www.google-analytics.com/analytics.js' async defer)

--- a/views/partials/footer.pug
+++ b/views/partials/footer.pug
@@ -1,5 +1,4 @@
 footer
   .container.text-center
     p.pull-left © 2018 Company, Inc. All Rights Reserved
-    iframe.pull-right(src="https://ghbtns.com/github-btn.html?user=Microsoft&repo=TypeScript-Node-Starter&type=star&count=true" frameborder="0" scrolling="0" width="90px" height="20px" style="margin-top:15px")
-      
+    iframe.pull-right(src="https://ghbtns.com/github-btn.html?user=Microsoft&repo=TypeScript-Node-Starter&type=star&count=true" width="90" height="20" style="margin-top:15px; border: 0; overflow: hidden;")


### PR DESCRIPTION
This commit:
- removes obsolate frameborder scrolling attributes from iframe
replacing them with inline style
- correct values for inline width/height for embedded iframe
- adds lang attr
- sort order of the head elements: see e.g. https://git.io/vNfEF
- update GA insline script to their shortest version and async/deferred script,
see: https://git.io/vNfuU
- use unbuffered comments so there is no output in transpiled html

Thanks!