### PR TITLE
Udate Jest transform confgiration part to match ts-jest patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,27 +302,29 @@ npm install -D jest ts-jest
 
 ### Configure Jest
 Jest's configuration lives in `jest.config.js`, so let's open it up and add the following code:
+
 ```js
 module.exports = {
-	globals: {
-		'ts-jest': {
-			tsConfigFile: 'tsconfig.json'
-		}
-	},
-	moduleFileExtensions: [
-		'ts',
-		'js'
-	],
-	transform: {
-		'^.+\\.(ts|tsx)$': './node_modules/ts-jest/preprocessor.js'
-	},
-	testMatch: [
-		'**/test/**/*.test.(ts|js)'
-	],
-	testEnvironment: 'node'
+    globals: {
+        'ts-jest': {
+            tsConfigFile: 'tsconfig.json'
+        }
+    },
+    moduleFileExtensions: [
+        'ts',
+        'js'
+    ],
+    transform: {
+        '^.+\\.tsx?$': 'ts-jest'
+    },
+    testMatch: [
+        '**/test/**/*.test.(ts|js)'
+    ],
+    testEnvironment: 'node'
 };
 ```
-Basically we are telling Jest that we want it to consume all files that match the pattern `"**/test/**/*.test.(ts|js)"` (all `.test.ts`/`.test.js` files in the `test` folder), but we want to preprocess the `.ts` files first. 
+
+Basically we are telling Jest that we want it to consume all files that match the pattern `"**/test/**/*.test.(ts|js)"` (all `.test.ts`/`.test.js` files in the `test` folder), but we want to preprocess the `.ts` files first using [`ts-jest` preprocessor](https://github.com/kulshekhar/ts-jest).
 This preprocess step is very flexible, but in our case, we just want to compile our TypeScript to JavaScript using our `tsconfig.json`.
 This all happens in memory when you run the tests, so there are no output `.js` test files for you to manage.   
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		'js'
 	],
 	transform: {
-		'^.+\\.(ts|tsx)$': './node_modules/ts-jest/preprocessor.js'
+		'^.+\\.tsx?$': 'ts-jest'
 	},
 	testMatch: [
 		'**/test/**/*.test.(ts|js)'


### PR DESCRIPTION
This PR wants to simplify information about Jest and `ts-jest` (TypeScript in general) by reusing information that could be found on `ts-jest` website about Jest configuration:
https://github.com/kulshekhar/ts-jest#usage

- same rule for transform is used
- the README content is updated
- tabs to spaces convertion

Thanks!

There is no difference in runtime tests after this change:
```sh
npm test

> express-typescript-starter@0.1.0 test /Users/piotrblazejewicz/git/TypeScript-Node-Starter
> jest --forceExit --coverage --verbose


 PASS  test/app.test.ts (5.708s)
  GET /random-url
    ✓ should return 404 (96ms)


GET / 200 593.220 ms - -
 PASS  test/api.test.ts (6.316s)
  GET /api
    ✓ should return 200 OK (684ms)

 PASS  test/home.test.ts (6.314s)
  GET /
    ✓ should return 200 OK (678ms)


 RUNS  test/user.test.ts
 PASS  test/contact.test.ts (6.404s)
  GET /contact
    ✓ should return 200 OK (668ms)
  POST /contact
    ✓ should return false from assert when no message is found (22ms)


 RUNS  test/user.test.ts

 PASS  test/user.test.ts (6.628s)al
  GET /login
    ✓ should return 200 OK (635ms)
  GET /signup
    ✓ should return 200 OK (150ms)
  POST /login
    ✓ should return some defined error message with valid parameters (20ms)

Test Suites: 5 passed, 5 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        7.08s
Ran all test suites.
```