### PR TITLE
Do not store output from coverage tests in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 
 # Ignore built ts files
 dist/**/*
+
+# Ignore output from coverage report
+coverage


### PR DESCRIPTION
A simple one: This allows to avoid manual removal of output after  test runs
from pending git changes

Thanks!