### PR TITLE
Change size existence check to default value

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -77,10 +77,7 @@ userSchema.methods.comparePassword = comparePassword;
 /**
  * Helper method for getting user's gravatar.
  */
-userSchema.methods.gravatar = function (size: number) {
-  if (!size) {
-    size = 200;
-  }
+userSchema.methods.gravatar = function (size: number = 200) {
   if (!this.email) {
     return `https://gravatar.com/avatar/?s=${size}&d=retro`;
   }


### PR DESCRIPTION
Using default value for size param in gravatar method is more convenient.