### PR TITLE
Add better logging when setting custom env var using .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Thumbs.db
 # Ignore built ts files
 dist/**/*
 
+# ignore yarn.lock
+yarn.lock

--- a/src/util/secrets.ts
+++ b/src/util/secrets.ts
@@ -21,6 +21,10 @@ if (!SESSION_SECRET) {
 }
 
 if (!MONGODB_URI) {
-    logger.error("No mongo connection string. Set MONGODB_URI environment variable.");
+    if (prod) {
+        logger.error("No mongo connection string. Set MONGODB_URI environment variable.");
+    } else {
+        logger.error("No mongo connection string. Set MONGODB_URI_LOCAL environment variable.");
+    }
     process.exit(1);
 }


### PR DESCRIPTION
this is more of a minor change but the error message is mis-leading when using `.env`. 

`MONGODB_URI_LOCAL` is used in all other environment other than production.

```sh
export const MONGODB_URI = prod ? process.env["MONGODB_URI"] : process.env["MONGODB_URI_LOCAL"];
```
Therefore, It should notify the user to set `MONGODB_URI_LOCAL` rather than `MONGODB_URI` if it is not **production**.
