### PR TITLE
fix(jest): Update deprecated ts-jest config option.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	globals: {
 		'ts-jest': {
-			tsConfigFile: 'tsconfig.json'
+			tsConfig: 'tsconfig.json'
 		}
 	},
 	moduleFileExtensions: [


### PR DESCRIPTION
### What does this PR do?
Resolves a warning running tests — this was consistently reproducible both locally and in CI. See e.g.,
[the latest Travis build](https://travis-ci.org/microsoft/TypeScript-Node-Starter/builds/533095625):

```console
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.tsConfigFile" is deprecated, use "[jest-config].globals.ts-jest.tsConfig" instead.
```

Simple one-line fix. 👌