### PR TITLE
added link to vscode TSLint extention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ npm run tslint  // runs only TSLint
 ```
 Notice that TSLint is not a part of the main watch task.
 It can be annoying for TSLint to clutter the output window while in the middle of writing a function, so I elected to only run it only during the full build.
-If you are interested in seeing TSLint feedback as soon as possible, I strongly recommend the [TSLint extension in VS Code]().
+If you are interested in seeing TSLint feedback as soon as possible, I strongly recommend the [TSLint extension in VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin).
 
 ### VSCode Extensions
 


### PR DESCRIPTION
the markdown code was present, but there was no actual link to follow.