### PR TITLE
Specify NodeJS version as strings in Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-    - 8
-    - 9
-    - 10
+    - "8"
+    - "9"
+    - "10"
 services:
     - mongodb
 cache:


### PR DESCRIPTION
This fixes the YAML related extensions errors in VSCode, as the
schema for .travis.yml requires a quoted strings here:
https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

Thanks!