### PR TITLE
:memo: remove reference to legacy file. Closes #190

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,9 @@ The full folder structure of this app is explained below:
 | .env.example             | API keys, tokens, passwords, database URI. Clone this, but don't check it in to public repos. |
 | .travis.yml              | Used to configure Travis CI build                                                             |
 | .copyStaticAssets.ts     | Build script that copies images, fonts, and JS libs to the dist folder                        |
-| jest.config.js           | Used to configure Jest                                                                        |
+| jest.config.js           | Used to configure Jest running tests written in TypeScript                                    |
 | package.json             | File that contains npm dependencies as well as [build scripts](#what-if-a-library-isnt-on-definitelytyped)                          |
 | tsconfig.json            | Config settings for compiling server code written in TypeScript                               |
-| tsconfig.tests.json      | Config settings for compiling tests written in TypeScript                                     |
 | tslint.json              | Config settings for TSLint code style checking                                                |
 
 ## Building the project


### PR DESCRIPTION
The configuration for Jest tests with support fo the TypeScript files
are now handled by Jest configuration file.

Thanks!