### PR TITLE
fix lint error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch-ts": "tsc -w",
     "build-sass": "node-sass src/public/css/main.scss dist/public/css/main.css",
     "watch-sass": "node-sass -w src/public/css/main.scss dist/public/css/main.css",
-    "lint": "tsc --noEmit && eslint '*/**/*.{js,ts}' --quiet --fix",
+    "lint": "tsc --noEmit && eslint \"*/**/*.{js,ts}\" --quiet --fix",
     "copy-static-assets": "ts-node copyStaticAssets.ts",
     "debug": "npm run build && npm run watch-debug",
     "serve-debug": "nodemon --inspect dist/server.js",


### PR DESCRIPTION
fix lint error
```
PS> npm run lint                                                                                                        
> express-typescript-starter@0.1.0 lint C:\Users\JipingWang\source\repos\api
> tsc --noEmit && eslint '*/**/*.{js,ts}' --quiet --fix


Oops! Something went wrong! :(

ESLint: 5.16.0.
No files matching the pattern "'*/**/*.{js,ts}'" were found.
Please check for typing mistakes in the pattern.

npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! express-typescript-starter@0.1.0 lint: `tsc --noEmit && eslint '*/**/*.{js,ts}' --quiet --fix`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the express-typescript-starter@0.1.0 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\JipingWang\AppData\Roaming\npm-cache\_logs\2019-07-18T15_26_05_580Z-debug.log
```