### PR TITLE
Fix lint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,8 @@
   },
   "rules": {
     "semi": ["error", "always"],
-    "quotes": ["error", "double"]
+    "quotes": ["error", "double"],
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,18 +1,18 @@
 module.exports = {
-	globals: {
-		'ts-jest': {
-			tsConfig: 'tsconfig.json'
-		}
-	},
-	moduleFileExtensions: [
-		'ts',
-		'js'
-	],
-	transform: {
-		'^.+\\.(ts|tsx)$': 'ts-jest'
-	},
-	testMatch: [
-		'**/test/**/*.test.(ts|js)'
-	],
-	testEnvironment: 'node'
+    globals: {
+        "ts-jest": {
+            tsConfig: "tsconfig.json"
+        }
+    },
+    moduleFileExtensions: [
+        "ts",
+        "js"
+    ],
+    transform: {
+        "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    testMatch: [
+        "**/test/**/*.test.(ts|js)"
+    ],
+    testEnvironment: "node"
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch-ts": "tsc -w",
     "build-sass": "node-sass src/public/css/main.scss dist/public/css/main.css",
     "watch-sass": "node-sass -w src/public/css/main.scss dist/public/css/main.css",
-    "lint": "tsc --noEmit && eslint \"*/**/*.{js,ts}\" --quiet --fix",
+    "lint": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
     "copy-static-assets": "ts-node copyStaticAssets.ts",
     "debug": "npm run build && npm run watch-debug",
     "serve-debug": "nodemon --inspect dist/server.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,6 @@ import compression from "compression";  // compresses requests
 import session from "express-session";
 import bodyParser from "body-parser";
 import lusca from "lusca";
-import dotenv from "dotenv";
 import mongo from "connect-mongo";
 import flash from "express-flash";
 import path from "path";


### PR DESCRIPTION
- Disables the rules `explicit-function-return-type` and `no-explicit-any` which causes many warnings for the current codebase.
- Expand linting to include root directory as well
