### PR TITLE
eslint, no any, no inferrable types, unused vars - warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,12 @@
     "semi": ["error", "always"],
     "quotes": ["error", "double"],
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-inferrable-types": "off"
+    "@typescript-eslint/no-explicit-any": 1,
+    "@typescript-eslint/no-inferrable-types": [
+      "warn", {
+        "ignoreParameters": true
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": "warn"
   }
 }


### PR DESCRIPTION
unused vars with "error" extremely annoying for developement;
"any" and inferrable types could and should be avoided, "warn" would make sense.