### PR TITLE
Updated readme to instruct to create Mongo's data/db directory under the home directory in macOS 10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,18 @@ npm install
 sudo mkdir -p /data/db
 # give the db correct read/write permissions
 sudo chmod 777 /data/db
+
+# starting from macOS 10.15 even the admin cannot create directory at root
+# so lets create the db diretory under the home directory.
+mkdir -p ~/data/db
+# user account has automatically read and write permissions for ~/data/db.
 ```
 - Start your mongoDB server (you'll probably want another command prompt)
-```
+```bash
 mongod
+
+# on macOS 10.15 or above the db directory is under home directory
+mongod --dbpath ~/data/db
 ```
 - Build and run the project
 ```


### PR DESCRIPTION
Updating the readme to mention the change in macOS and offer an alternative location for Mongo's data/db directory.