### PR TITLE
:lipstick: Minor changes to form client validation.

### DIFF
--- a/views/account/profile.pug
+++ b/views/account/profile.pug
@@ -10,7 +10,7 @@ block content
     .form-group.row.justify-content-md-center
       label.col-sm-3.col-form-label.text-right.font-weight-bold(for='email') Email
       .col-sm-7
-        input.form-control(type='email', name='email', id='email', value=user.email)
+        input.form-control(type='email', name='email', id='email', value=user.email, autofocus, required)
     .form-group.row.justify-content-md-center
       label.col-sm-3.col-form-label.text-right.font-weight-bold(for='name') Name
       .col-sm-7
@@ -54,11 +54,11 @@ block content
     .form-group.row.justify-content-md-center
       label.col-sm-3.col-form-label.text-right.font-weight-bold(for='password') New Password
       .col-sm-7
-        input.form-control(type='password', name='password', id='password')
+        input.form-control(type='password', name='password', id='password', minlength='4', required)
     .form-group.row.justify-content-md-center
       label.col-sm-3.col-form-label.text-right.font-weight-bold(for='confirmPassword') Confirm Password
       .col-sm-7
-        input.form-control(type='password', name='confirmPassword', id='confirmPassword')
+        input.form-control(type='password', name='confirmPassword', id='confirmPassword', minlength='4', required)
     .form-group.row.justify-content-md-center
       .col-sm-4
         button.btn.btn-primary(type='submit')

--- a/views/account/reset.pug
+++ b/views/account/reset.pug
@@ -8,10 +8,10 @@ block content
       input(type='hidden', name='_csrf', value=_csrf)
       .form-group
         label.col-form-label.font-weight-bold(for='password') New Password
-        input.form-control(type='password', name='password', id='password', placeholder='New password', autofocus, required)
+        input.form-control(type='password', name='password', id='password', placeholder='New password', autofocus, required, minlength='4')
       .form-group
         label.col-form-label.font-weight-bold(for='confirm') Confirm Password
-        input.form-control(type='password', name='confirm', id='confirm', placeholder='Confirm password', required)
+        input.form-control(type='password', name='confirm', id='confirm', placeholder='Confirm password', required, minlength='4')
       .form-group
         button.btn.btn-primary.btn-reset(type='submit')
           i.fa.fa-keyboard-o

--- a/views/account/signup.pug
+++ b/views/account/signup.pug
@@ -13,11 +13,11 @@ block content
     .form-group.row.justify-content-md-center
       label.col-sm-3.col-form-label.text-right.font-weight-bold(for='password') Password
       .col-sm-7
-        input.form-control(type='password', name='password', id='password', placeholder='Password', required)
+        input.form-control(type='password', name='password', id='password', placeholder='Password', required, minlength='4')
     .form-group.row.justify-content-md-center
       label.col-sm-3.col-form-label.text-right.font-weight-bold(for='confirmPassword') Confirm Password
       .col-sm-7
-        input.form-control(type='password', name='confirmPassword', id='confirmPassword', placeholder='Confirm Password', required)
+        input.form-control(type='password', name='confirmPassword', id='confirmPassword', placeholder='Confirm Password', required, minlength='4')
     .form-group.row.justify-content-md-center
       .offset-sm-3.col-sm-7
         button.btn.btn-success(type='submit')

--- a/views/contact.pug
+++ b/views/contact.pug
@@ -10,15 +10,15 @@ block content
     .form-group.row.justify-content-md-center
       label.col-sm-2.col-form-label.text-right.font-weight-bold(for='name') Name
       .col-sm-8
-        input.form-control(type='text', name='name', id='name', autofocus=true)
+        input.form-control(name='name', id='name', autofocus, required)
     .form-group.row.justify-content-md-center
       label.col-sm-2.col-form-label.text-right.font-weight-bold(for='email') Email
       .col-sm-8
-        input.form-control(type='text', name='email', id='email')
+        input.form-control(type='email', name='email', id='email', required)
     .form-group.row.justify-content-md-center
       label.col-sm-2.col-form-label.text-right.font-weight-bold(for='message') Body
       .col-sm-8
-        textarea.form-control(name='message', id='message', rows='7')
+        textarea.form-control(name='message', id='message', rows='7', required)
     .form-group.row.justify-content-md-center
       .offset-sm-2.col-sm-8
         button.btn.btn-primary(type='submit')


### PR DESCRIPTION
As the follow-up to the #247 these are changes that align validation on
the client part with the validation on the backend part:
- min lenght for password (all forms)
- required fields in the profile page form
- reuiqred fields in the contact page form
- autofocus first input within forms

Thanks!