### PR TITLE
vscode-eslint v2 settings patch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,9 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "eslint.autoFixOnSave": true,
-  "eslint.validate": [
-    "javascript",
-    { "language": "typescript", "autoFix": true }
-  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": ["javascript", "typescript"],
   "editor.formatOnSave": true,
   "[javascript]": {
     "editor.formatOnSave": false


### PR DESCRIPTION
[dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) has deprecated `eslint.autoFixOnSave` among other changes/improvements in version 2.0.4.

Updated `settings.json` to fix the following errors:
- The setting is deprecated. Use editor.codeActionsOnSave instead with a source.fixAll.eslint member.
- Auto Fix is enabled by default. Use the single string form.
![image](https://user-images.githubusercontent.com/5100938/71754156-a93c9980-2e4a-11ea-8a94-ad92fec62cd5.png)
