### PR TITLE
update(ts-jest): update `ts-config` configuratin for 6.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Jest's configuration lives in `jest.config.js`, so let's open it up and add the 
 module.exports = {
     globals: {
         'ts-jest': {
-            tsConfigFile: 'tsconfig.json'
+            tsconfigFile: 'tsconfig.json'
         }
     },
     moduleFileExtensions: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     globals: {
         "ts-jest": {
-            tsConfig: "tsconfig.json"
+            tsconfig: "tsconfig.json"
         }
     },
     moduleFileExtensions: [


### PR DESCRIPTION
This removes warnings about deprecated configuration option:

```text
tsConfig` is depecrated and will be removed in ts-jest 27
```

https://github.com/kulshekhar/ts-jest/commit/8fec6816e1b6009c4ba9b41f111c896d3c2fc3f5

Thanks!